### PR TITLE
Update search page with certification dropdowns

### DIFF
--- a/lib/models/education_model.dart
+++ b/lib/models/education_model.dart
@@ -3,12 +3,20 @@ import 'package:flutter/material.dart';
 class CertTypeModel {
   final int id;
   final String certificationName;
+  final String name;
 
-  CertTypeModel({required this.id, required this.certificationName});
+  CertTypeModel({
+    required this.id,
+    required this.certificationName,
+    required this.name,
+  });
 
   factory CertTypeModel.fromJson(Map<String, dynamic> json) {
     return CertTypeModel(
-        id: json['id'], certificationName: json['certification']['name']);
+      id: json['id'],
+      certificationName: json['certification']['name'],
+      name: json['name'],
+    );
   }
 }
 

--- a/lib/secreens/search_page.dart
+++ b/lib/secreens/search_page.dart
@@ -18,13 +18,15 @@ class SearchPage extends StatefulWidget {
 
 class _SearchPageState extends State<SearchPage> {
   List<CertTypeModel> certTypes = [];
+  List<String> certifications = [];
+  String? selectedCertification;
   bool isCertLoading = true;
 
   List<YearModel> years = [];
   YearModel? selectedYear;
   bool isLoading = true;
 
-  int? certTypeId ;
+  int? certTypeId;
   int? eYearId;
   final TextEditingController numberController = TextEditingController();
 
@@ -45,8 +47,11 @@ class _SearchPageState extends State<SearchPage> {
 
       if (response.statusCode == 200) {
         final List data = jsonDecode(response.body)['data'];
+        final types = data.map((e) => CertTypeModel.fromJson(e)).toList();
         setState(() {
-          certTypes = data.map((e) => CertTypeModel.fromJson(e)).toList();
+          certTypes = types;
+          certifications =
+              types.map((e) => e.certificationName).toSet().toList();
           isCertLoading = false;
         });
       } else {
@@ -147,21 +152,47 @@ class _SearchPageState extends State<SearchPage> {
                           ),
                           const SizedBox(height: 20),
 
-                          // نوع الشهادة
+                          // قائمة الشهادات
 
-                          DropdownButtonFormField<int>(
+                          DropdownButtonFormField<String>(
                             decoration: const InputDecoration(
                               prefixIcon: Icon(Icons.school),
-                              labelText: "Certificate Type",
+                              labelText: "Certificate",
                               border: OutlineInputBorder(),
                             ),
-                            items: certTypes.map((cert) {
-                              return DropdownMenuItem<int>(
-                                value: cert.id,
-                                child: Text(cert.certificationName),
-                              );
-                            }).toList(),
+                            value: selectedCertification,
+                            items: certifications
+                                .map((name) => DropdownMenuItem<String>(
+                                      value: name,
+                                      child: Text(name),
+                                    ))
+                                .toList(),
+                            onChanged: (value) {
+                              setState(() {
+                                selectedCertification = value;
+                                certTypeId = null; // reset branch selection
+                              });
+                            },
+                          ),
 
+                          const SizedBox(height: 12),
+
+                          // قائمة الافراع
+                          DropdownButtonFormField<int>(
+                            decoration: const InputDecoration(
+                              prefixIcon: Icon(Icons.school_outlined),
+                              labelText: "Branch",
+                              border: OutlineInputBorder(),
+                            ),
+                            value: certTypeId,
+                            items: certTypes
+                                .where((c) =>
+                                    c.certificationName == selectedCertification)
+                                .map((c) => DropdownMenuItem<int>(
+                                      value: c.id,
+                                      child: Text(c.name),
+                                    ))
+                                .toList(),
                             onChanged: (value) {
                               setState(() {
                                 certTypeId = value;


### PR DESCRIPTION
## Summary
- extend `CertTypeModel` with a `name` field
- add certificate and branch dropdowns to the search page

## Testing
- `flutter test` *(fails: `flutter: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_68555e52ced88321804c6190eb2a5e08